### PR TITLE
Node Attribute Lifting

### DIFF
--- a/configs/transforms/liftings/graph2hypergraph/attribute_lifting.yaml
+++ b/configs/transforms/liftings/graph2hypergraph/attribute_lifting.yaml
@@ -1,0 +1,4 @@
+transform_type: 'lifting'
+transform_name: "NodeAttributeLifting"
+attribute_idx: 0
+feature_lifting: ProjectionSum

--- a/modules/transforms/data_transform.py
+++ b/modules/transforms/data_transform.py
@@ -9,6 +9,9 @@ from modules.transforms.data_manipulations.manipulations import (
 )
 from modules.transforms.feature_liftings.feature_liftings import ProjectionSum
 from modules.transforms.liftings.graph2cell.cycle_lifting import CellCycleLifting
+from modules.transforms.liftings.graph2hypergraph.attribute_lifting import (
+    NodeAttributeLifting,
+)
 from modules.transforms.liftings.graph2hypergraph.knn_lifting import (
     HypergraphKNNLifting,
 )
@@ -19,6 +22,7 @@ from modules.transforms.liftings.graph2simplicial.clique_lifting import (
 TRANSFORMS = {
     # Graph -> Hypergraph
     "HypergraphKNNLifting": HypergraphKNNLifting,
+    "HypergraphNodeAttributeLifting": NodeAttributeLifting,
     # Graph -> Simplicial Complex
     "SimplicialCliqueLifting": SimplicialCliqueLifting,
     # Graph -> Cell Complex

--- a/modules/transforms/liftings/graph2hypergraph/attribute_lifting.py
+++ b/modules/transforms/liftings/graph2hypergraph/attribute_lifting.py
@@ -1,0 +1,50 @@
+import warnings
+
+import networkx
+import torch
+import torch_geometric
+
+from modules.transforms.liftings.graph2hypergraph.base import Graph2HypergraphLifting
+
+
+class NodeAttributeLifting(Graph2HypergraphLifting):
+    r"""Lifts graphs to hypergraph domain by grouping nodes with the same attribute.
+
+    Parameters
+    ----------
+    attribute_idx : int
+        The index of the node attribute to use for hyperedge construction.
+    """
+
+    def __init__(self, attribute_idx: int, **kwargs):
+        super().__init__(**kwargs)
+        self.attribute_idx = attribute_idx
+
+    def lift_topology(self, data: torch_geometric.data.Data) -> dict:
+        r"""Lifts the topology of a graph to hypergraph domain by grouping nodes with the same attribute.
+
+        Parameters
+        ----------
+        data : torch_geometric.data.Data
+            The input data to be lifted.
+
+        Returns
+        -------
+        dict
+            The lifted topology.
+        """
+        attribute = data.x[:, self.attribute_idx]
+        unique_attributes = torch.unique(attribute)
+        num_hyperedges = unique_attributes.size(0)
+
+        incidence_1 = torch.zeros(data.num_nodes, num_hyperedges)
+        for i, attr in enumerate(unique_attributes):
+            nodes_with_attr = torch.where(attribute == attr)[0]
+            incidence_1[nodes_with_attr, i] = 1
+
+        incidence_1 = incidence_1.to_sparse_coo()
+        return {
+            "incidence_hyperedges": incidence_1,
+            "num_hyperedges": num_hyperedges,
+            "x_0": data.x,
+        }

--- a/test/transforms/liftings/graph2hypergraph/test_attribute_lifting.py
+++ b/test/transforms/liftings/graph2hypergraph/test_attribute_lifting.py
@@ -1,0 +1,49 @@
+import torch
+import torch_geometric
+
+from modules.data.utils.utils import load_manual_graph
+from modules.transforms.liftings.graph2hypergraph.attribute_lifting import (
+    NodeAttributeLifting,
+)
+
+
+class TestNodeAttributeLifting:
+    """Test the NodeAttributeLifting class."""
+
+    def setup_method(self):
+        # Set up a simple manual graph for testing
+        self.data = torch_geometric.data.Data(
+            x=torch.tensor(
+                [
+                    [1, 0],
+                    [1, 0],
+                    [0, 1],
+                    [0, 1],
+                ],
+                dtype=torch.float,
+            ),
+            edge_index=torch.tensor([[0, 1, 2, 3], [1, 0, 3, 2]], dtype=torch.long),
+        )
+        self.lifting = NodeAttributeLifting(attribute_idx=0)
+
+    def test_lift_topology(self):
+        # Test the lift_topology method
+        lifted_topology = self.lifting.lift_topology(self.data.clone())
+
+        expected_n_hyperedges = 2
+        expected_incidence_1 = torch.tensor(
+            [
+                [1.0, 0.0],
+                [1.0, 0.0],
+                [0.0, 1.0],
+                [0.0, 1.0],
+            ]
+        ).to_sparse_coo()
+
+        assert torch.equal(
+            expected_incidence_1.to_dense(),
+            lifted_topology["incidence_hyperedges"].to_dense(),
+        ), "Something is wrong with incidence_hyperedges."
+        assert (
+            expected_n_hyperedges == lifted_topology["num_hyperedges"]
+        ), "Something is wrong with the number of hyperedges."


### PR DESCRIPTION
This method involves lifting a graph to a hypergraph based on node attributes. Hyperedges are created by grouping nodes with the same attribute. Given \(n\) attributes of a node, users can choose which attribute to use for constructing the hyperedges. Additionally, users can preprocess the data to add new attributes for grouping. For example, in a social network, hyperedges can represent people from same city, or nodes can be grouped based on domain-specific distances.

This lifting approach is particularly useful for datasets where node attributes are present. For instance, the MUTAG, ENZYMES, and PROTEINS datasets all have this property. We tested our method on these datasets and updated the tutorial accordingly.